### PR TITLE
Update rolldice.py

### DIFF
--- a/rolldice/rolldice.py
+++ b/rolldice/rolldice.py
@@ -128,7 +128,7 @@ class SimpleEval(object):
         self.functions = DEFAULT_FUNCTIONS
 
         self.nodes = {
-            ast.Num: self._eval_num,
+            ast.Constant: self._eval_num,
             ast.UnaryOp: self._eval_unaryop,
             ast.BinOp: self._eval_binop,
         }


### PR DESCRIPTION
Replace 'ast.Num' with 'ast.Constant' as 'ast.Num' is deprecated as of Python 3.8

Seems to fix #2 
Might make the module not work properly under earlier Python versions (3.7 and before)