### PR TITLE
Make changes work with Python 3.7.x and lower

### DIFF
--- a/rolldice/rolldice.py
+++ b/rolldice/rolldice.py
@@ -15,6 +15,7 @@ import ast
 import regex
 import operator
 import math
+import sys
 
 class DiceGroupException(Exception):  # Exception for when dice group is malformed, ie '12d6>7!'
     def __init__(self, *args, **kwargs):
@@ -127,11 +128,18 @@ class SimpleEval(object):
 
         self.functions = DEFAULT_FUNCTIONS
 
-        self.nodes = {
-            ast.Constant: self._eval_num,
-            ast.UnaryOp: self._eval_unaryop,
-            ast.BinOp: self._eval_binop,
-        }
+        if sys.version_info < (3, 8):
+            self.nodes = {
+                ast.Num: self._eval_num,
+                ast.UnaryOp: self._eval_unaryop,
+                ast.BinOp: self._eval_binop,
+            }
+        else:
+            self.nodes = {
+                ast.Constant: self._eval_num,
+                ast.UnaryOp: self._eval_unaryop,
+                ast.BinOp: self._eval_binop,
+            }
 
         if functions:
             self.nodes[ast.Call] = self._eval_call


### PR DESCRIPTION
Make the previous change work in Python 3.8+ and keep the old code for backward compatibility (and still fixes #2)
Could probably be a bit more elegant but this works (tested in both 3.8.2 and 3.6.8 and worked fine)

(sorry for the new PR, I don't have a lot of experience with GH and PRs)